### PR TITLE
Ability to make command interactive

### DIFF
--- a/src/Classes/Executor.php
+++ b/src/Classes/Executor.php
@@ -132,18 +132,7 @@ abstract class Executor
     private function runCommand(string $commandToRun, bool $isInteractive = false): void
     {
         if ($isInteractive) {
-            // This function is similar to exec(), However, it sends the raw output from the program to the output stream
-            // with which PHP is currently working (i.e. either HTTP in a web server scenario, or the shell in a command line version of PHP).
-            // for more info see: https://php.net/manual/en/function.passthru.php
-            // use escapeshellcmd() to return the command in a safe format that can be used.
-            passthru(escapeshellcmd($commandToRun), $status);
-            if ($status == 0) {
-                // success
-                $this->setOutput('Interactive command completed');
-            } else {
-                // failure
-                $this->setOutput('Interactive command failed');
-            }
+            $this->runInteractiveCommand($commandToRun);
 
             return;
         }
@@ -161,6 +150,21 @@ abstract class Executor
         $output = $process->isSuccessful() ? $process->getOutput() : $process->getErrorOutput();
 
         $this->setOutput($this->getOutput().$output);
+    }
+
+    /**
+     * Handle the running of an interactive console command.
+     *
+     * @param string $commandToRun
+     */
+    private function runInteractiveCommand(string $commandToRun): void
+    {
+        passthru(escapeshellcmd($commandToRun), $status);
+        if ($status == 0) {
+            $this->setOutput($this->getOutput().' Interactive command completed');
+        } else {
+            $this->setOutput($this->getOutput().' Interactive command failed');
+        }
     }
 
     /**

--- a/src/Classes/Executor.php
+++ b/src/Classes/Executor.php
@@ -144,6 +144,7 @@ abstract class Executor
                 // failure
                 $this->setOutput('Interactive command failed');
             }
+            
             return;
         }
 

--- a/src/Classes/Executor.php
+++ b/src/Classes/Executor.php
@@ -144,7 +144,7 @@ abstract class Executor
                 // failure
                 $this->setOutput('Interactive command failed');
             }
-            
+
             return;
         }
 

--- a/tests/Unit/Classes/ExecutorTest.php
+++ b/tests/Unit/Classes/ExecutorTest.php
@@ -104,6 +104,20 @@ class ExecutorTest extends TestCase
     }
 
     /** @test */
+    public function interactive_command_added_to_the_executor_can_be_run()
+    {
+        $executor = new class extends Executor {
+            public function run(): Executor
+            {
+                return $this->runExternal('echo anything', true);
+            }
+        };
+
+        $executor->run();
+        $this->assertEquals('Interactive command completed', trim($executor->getOutput()));
+    }
+
+    /** @test */
     public function url_can_be_pinged()
     {
         $guzzleMock = Mockery::mock(Client::class)->makePartial();


### PR DESCRIPTION
This pr adds the ability to make artisan/external command interactive by using passthru() to execute it instead of the Process class. Its downside that we can't take it's output but rather capture the exit status of the shell program and then set custom output message. for more info about the function check the [manual](https://www.php.net/manual/en/function.passthru.php).
This pr should solve #6 issue.